### PR TITLE
Fix startup check for JSON logging

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'andy.k.dufour@gmail.com'
 license 'All rights reserved'
 description 'Installs/Configures jboss7'
 long_description 'Installs/Configures jboss7'
-version '0.11.2'
+version '0.11.3'
 
 depends 'apt'
 depends 'java'

--- a/templates/default/debian/jboss7-init.erb
+++ b/templates/default/debian/jboss7-init.erb
@@ -170,7 +170,7 @@ case "$1" in
 		launched=0
 		until [ $count -gt $STARTUP_WAIT ]
 		do
-			grep 'JBAS015874:' $JBOSS_CONSOLE_LOG > /dev/null
+			grep 'org\.jboss\.as.*started in' $JBOSS_CONSOLE_LOG > /dev/null
 			if [ $? -eq 0 ] ; then
 				launched=1
 				break

--- a/templates/default/redhat/jboss-init.erb
+++ b/templates/default/redhat/jboss-init.erb
@@ -98,7 +98,7 @@ start() {
 
   until [ $count -gt $STARTUP_WAIT ]
   do
-    grep 'JBoss AS.*started in' $JBOSS_CONSOLE_LOG > /dev/null
+    grep 'org\.jboss\.as.*started in' $JBOSS_CONSOLE_LOG > /dev/null
     if [ $? -eq 0 ] ; then
       launched=true
       break


### PR DESCRIPTION
# Motivation

Change the recipe to check for logs in the new format when confirming EAP service startup.
# Changes
- update grep regex to match new logger output

ping @matzew @mikenairn 
